### PR TITLE
refactor(ci): add `on.workflow_call` option to sync-labeler.yml

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -2,6 +2,7 @@ name: Sync labels
 
 on:
   workflow_dispatch:
+  workflow_call:
     inputs:
       prune:
         required: false
@@ -11,6 +12,10 @@ on:
         required: false
         type: string
         default: '.github/labels.yml'
+    secrets:
+      token:
+        description: "Github token"
+        required: true
   push:
     branches:
       - main
@@ -25,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: micnncim/action-label-syncer@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.token }}
         with:
           manifest: ${{ inputs.target }}
           prune: ${{ inputs.prune }}


### PR DESCRIPTION
## 🔗 Related

- #56
- #57  
- #61 

## 📚 Description

- [x] `sync-labeler.yml`に`on_workflow_call` optionを追加
