### PR TITLE
fix(ci): Remove env from get-month workflow

### DIFF
--- a/.github/workflows/get-month.yml
+++ b/.github/workflows/get-month.yml
@@ -27,9 +27,6 @@ jobs:
     if: inputs.isMonth 
     runs-on: ubuntu-24.04
     timeout-minutes: 1
-    env:
-      GH_TOKEN: ${{ secrets.token }}
-      GH_REPO: ${{ secrets.repo }}
     outputs:
       month: ${{ steps.run-date-command-for-m.outputs.month }}
     steps:


### PR DESCRIPTION
## 🔗 Issue

closed #76 .

## 📚 Description

- [x] 未使用の環境変数を削除

